### PR TITLE
fix: specify default tier in submysterygift

### DIFF
--- a/src/data-mocks/submysterygift.js
+++ b/src/data-mocks/submysterygift.js
@@ -1,5 +1,6 @@
 export const defaults = {
 	giftcount: 5,
+	tier: 1,
 }
 
 /**


### PR DESCRIPTION
Resolves issue where msg-param-sub-plan would be null and msg-param-sub-plan-name malformed, if a specific tier was not passed.

Thanks to @Mrbysco for their help in identification of the bug.

Apologies for the unsuccessful rebase attempt in the previous PR