### PR TITLE
fix(subgift): ensure msg-param-months is present

### DIFF
--- a/src/data-mocks/subgift.js
+++ b/src/data-mocks/subgift.js
@@ -75,7 +75,7 @@ export const render = (args = {}) => {
 		login: username,
 		mod: 0,
 		'msg-id': 'subgift',
-		'msg-param-months': 0,
+		'msg-param-months': 1,
 		'msg-param-recipient-display-name': username2,
 		'msg-param-recipient-id': userid2,
 		'msg-param-recipient-user-name': username2,

--- a/src/data-mocks/subgift.js
+++ b/src/data-mocks/subgift.js
@@ -15,6 +15,7 @@ const { HOST } = process.env
 export const defaults = {
 	count: 1,
 	months: 1,
+	tenure: 1,
 	tier: 1,
 }
 
@@ -26,13 +27,14 @@ export const defaults = {
  * @param {string} channel - The name of the channel the message will be sent to.
  * @param {string} channelid - The ID of the channel the message will be sent to.
  * @param {string} color - The color of the user's name in chat.
- * @param {string} count - The total number of gifts the user has given in the channel.
+ * @param {string} count=1 - The total number of gifts the user has given in the channel.
  * @param {string} messageid - The ID of the message.
- * @param {number} months - The length of the gift sub (for multi-month subs only).
+ * @param {number} months=1 - The length of the gift sub (for multi-month subs only).
+ * @param {number} tenure=1 - The total number of months the recipient has been subscribed.
  * @param {number} tier=1 - The tier of the subscription being extended.
  * @param {string} timestamp - The millisecond timestamp when the message was sent.
- * @param {string} userid2 - The ID of the user that is gifting the sub.
- * @param {string} username2 - The username of the user that is gifting the sub.
+ * @param {string} userid2 - The ID of the user that is receiving the sub.
+ * @param {string} username2 - The username of the user that is receiving the sub.
  * @param {string} userid - The ID of the user sending the message.
  * @param {string} username - The username of the user sending the message.
  *
@@ -50,6 +52,7 @@ export const render = (args = {}) => {
 		count,
 		messageid,
 		months,
+		tenure,
 		tier,
 		timestamp,
 		userid,
@@ -75,7 +78,7 @@ export const render = (args = {}) => {
 		login: username,
 		mod: 0,
 		'msg-id': 'subgift',
-		'msg-param-months': 1,
+		'msg-param-months': Math.max(tenure, 1),
 		'msg-param-recipient-display-name': username2,
 		'msg-param-recipient-id': userid2,
 		'msg-param-recipient-user-name': username2,

--- a/test/commands/subgift.test.js
+++ b/test/commands/subgift.test.js
@@ -26,6 +26,7 @@ import User from 'structures/User'
 // Local constants
 const testChannelName = 'TestChannel'
 const testMultiMonthSubLength = 3
+const testSubTenure = 2
 const testOauthToken = 'oauth:1234567890'
 const testUsername = 'Bob'
 const ircSocket = class extends EventEmitter {
@@ -122,5 +123,14 @@ describe('subgift events', function() {
 		const { tags } = parseIRCMessage(rawMessage)
 
 		expect(tags['msg-params-gift-months']).to.equal(`${testMultiMonthSubLength}`)
+	})
+
+	it('should set the subscription tenure', () => {
+		socket.emit('message', `PRIVMSG #${testChannelName} :subgift --tenure ${testSubTenure}`)
+
+		const rawMessage = connection.send.getCall(0).firstArg
+		const { tags } = parseIRCMessage(rawMessage)
+
+		expect(tags['msg-param-months']).to.equal(`${testSubTenure}`)
 	})
 })


### PR DESCRIPTION
Default to one month instead of zero so the tag is actually sent (was causing `NumberFormatException` for us when absent)

Bug found by @Mrbysco
