### PR TITLE
Fix room state events

### DIFF
--- a/src/data-mocks/emoteonly.js
+++ b/src/data-mocks/emoteonly.js
@@ -29,17 +29,20 @@ export const defaults = {
  */
 export const render = (args = {}) => {
 	const {
-		channel,
+		channel: channelName,
+		connection,
 		off,
 	} = {
 		...defaults,
 		...args,
 	}
 
+	const channel = connection.channels.findByName(channelName)
+
 	channel.emoteOnly = !off
 
 	return {
-		message: `${HOST} NOTICE #${channel} :This room is ${off ? 'no longer' : 'now'} in emote-only mode.`,
+		message: `${HOST} NOTICE #${channelName} :This room is ${off ? 'no longer' : 'now'} in emote-only mode.`,
 		'msg-id': `emote_only_${off ? 'off' : 'on'}`,
 	}
 }

--- a/src/data-mocks/slowmode.js
+++ b/src/data-mocks/slowmode.js
@@ -29,17 +29,20 @@ export const defaults = {
  */
 export const render = (args = {}) => {
 	const {
-		channel,
+		channel: channelName,
+		connection,
 		off,
 	} = {
 		...defaults,
 		...args,
 	}
 
+	const channel = connection.channels.findByName(channelName)
+
 	channel.slowMode = !off
 
 	return {
-		message: `${HOST} NOTICE #${channel} :This room is ${off ? 'no longer' : 'now'} in slow mode.${off ? '' : ' You can send messages every 30 seconds.'}`,
+		message: `${HOST} NOTICE #${channelName} :This room is ${off ? 'no longer' : 'now'} in slow mode.${off ? '' : ' You can send messages every 30 seconds.'}`,
 		'msg-id': `slow_${off ? 'off' : 'on'}`,
 	}
 }

--- a/src/data-mocks/subsonly.js
+++ b/src/data-mocks/subsonly.js
@@ -29,17 +29,20 @@ export const defaults = {
  */
 export const render = (args = {}) => {
 	const {
-		channel,
+		channel: channelName,
+		connection,
 		off,
 	} = {
 		...defaults,
 		...args,
 	}
 
+	const channel = connection.channels.findByName(channelName)
+
 	channel.subsOnly = !off
 
 	return {
-		message: `${HOST} NOTICE #${channel} :This room is ${off ? 'no longer' : 'now'} in subscribers-only mode.`,
+		message: `${HOST} NOTICE #${channelName} :This room is ${off ? 'no longer' : 'now'} in subscribers-only mode.`,
 		'msg-id': `subs_${off ? 'off' : 'on'}`,
 	}
 }

--- a/src/helpers/handleJOINMessage.js
+++ b/src/helpers/handleJOINMessage.js
@@ -37,8 +37,9 @@ export default (message, connection) => {
 			`:${username}!${username}@${username}.${HOST} JOIN #${channel.name}`,
 			`:${username}.${HOST} 353 ${username} = #${channel.name} :${username}`,
 			`:${username}.${HOST} 366 ${username} #${channel.name} :End of /NAMES list`,
-			`@badge-info=;badges=;color=${user.color};display-name=${user.displayName};emote-sets=0;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #${channel.name}`,
-			`@emote-only=${Number(channel.emoteOnly)};followers-only=${Number(channel.followersOnly)};r9k=0;rituals=0;room-id=${channel.id};slow=${Number(channel.slowMode)};subs-only=${Number(channel.subsOnly)} :tmi.twitch.tv ROOMSTATE #${channel.name}`,
 		])
+
+		user.sendUSERSTATE(channel.name)
+		channel.sendROOMSTATE()
 	})
 }

--- a/src/helpers/handlePRIVMSGMessage.js
+++ b/src/helpers/handlePRIVMSGMessage.js
@@ -57,6 +57,7 @@ export default (messageData, connection) => {
 		args,
 		channel,
 		command,
+		connection,
 		user,
 	})
 

--- a/src/helpers/handlePRIVMSGMessage.js
+++ b/src/helpers/handlePRIVMSGMessage.js
@@ -25,7 +25,6 @@ export default (messageData, connection) => {
 		getChannel,
 		getUser,
 		send,
-		username,
 	} = connection
 	const [channelName, message] = messageData.params
 
@@ -47,10 +46,15 @@ export default (messageData, connection) => {
 
 	args.message = messageBody.join(' ')
 
+	const username = args.username || connection.username
+
 	let user = getUser(username)
 
-	if (args.username) {
-		user = new User({ username: args.username })
+	if (!user) {
+		user = new User({
+			connection,
+			username,
+		})
 	}
 
 	const response = renderCommandResponse({

--- a/src/helpers/renderCommandResponse.js
+++ b/src/helpers/renderCommandResponse.js
@@ -11,6 +11,7 @@ export default options => {
 		args,
 		channel,
 		command,
+		connection,
 		user,
 	} = options
 
@@ -19,6 +20,7 @@ export default options => {
 			args,
 			channel,
 			command,
+			connection,
 			template: getMock({ command }),
 			user,
 		})

--- a/src/helpers/renderMessage.js
+++ b/src/helpers/renderMessage.js
@@ -10,6 +10,7 @@ export default options => {
 	const {
 		args,
 		channel,
+		connection,
 		template,
 		user,
 	} = options
@@ -18,6 +19,7 @@ export default options => {
 		const renderedTemplate = renderTemplate({
 			args,
 			channel,
+			connection,
 			template,
 			user,
 		})

--- a/src/helpers/renderTemplate.js
+++ b/src/helpers/renderTemplate.js
@@ -17,6 +17,7 @@ export default options => {
 	const {
 		args = {},
 		channel,
+		connection,
 		template,
 		user,
 	} = options
@@ -24,6 +25,7 @@ export default options => {
 		channel: channel?.name,
 		channelid: channel?.id,
 		color: user?.color,
+		connection,
 		host: HOST,
 		id: messageID,
 		messageid: messageID,

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -106,6 +106,22 @@ export default class extends UserList {
 		}))
 	}
 
+	sendROOMSTATE = () => {
+		this.connection.send(renderMessage({
+			channel: this,
+			template: () => ({
+				'emote-only': Number(this.emoteOnly),
+				'followers-only': Number(this.followersOnly),
+				r9k: 0,
+				rituals: 0,
+				'room-id': this.id,
+				slow: Number(this.slowMode),
+				'subs-only': Number(this.subsOnly),
+				message: `${HOST} ROOMSTATE #${this.name}`,
+			}),
+		}))
+	}
+
 
 
 

--- a/src/structures/Connection.js
+++ b/src/structures/Connection.js
@@ -251,11 +251,14 @@ export default class extends EventEmitter {
 		return channel
 	}
 
-	getUser = (username, create = true) => {
+	getUser = username => {
 		let user = this.users.findByUsername(username)
 
-		if (!user && create) {
-			user = new User({ username })
+		if (!user) {
+			user = new User({
+				connection: this,
+				username,
+			})
 			this.users.add(user)
 		}
 

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -6,6 +6,20 @@ import tinycolor from 'tinycolor2'
 
 
 
+// Local imports
+import renderMessage from 'helpers/renderMessage'
+
+
+
+
+
+// Local constants
+const { HOST } = process.env
+
+
+
+
+
 export default class {
 	/***************************************************************************\
 		Local Properties
@@ -27,6 +41,22 @@ export default class {
 		this.options = options
 	}
 
+	sendUSERSTATE = channelName => {
+		this.connection.send(renderMessage({
+			template: () => ({
+				'badge-info': null,
+				badges: null,
+				color: this.color,
+				'display-name': this.displayName,
+				'emote-sets': 0,
+				mod: 0,
+				subscriber: 0,
+				'user-type': null,
+				message: `${HOST} USERSTATE #${channelName}`
+			}),
+		}))
+	}
+
 
 
 
@@ -34,6 +64,10 @@ export default class {
 	/***************************************************************************\
 		Getters
 	\***************************************************************************/
+
+	get connection () {
+		return this.options.connection
+	}
 
 	get displayName () {
 		return this.options.username


### PR DESCRIPTION
Setting room states (`emoteonly`, `subsonly`, `slowmode`) were busted because of a previous refactoring of haw we accessed channel names in templates. This PR fixes it by passing the connection object through to the templates so they can retrieve bits of meta as necessary.