### PR TITLE
Respond to PING messages with the same params

### DIFF
--- a/src/helpers/handlePINGMessage.js
+++ b/src/helpers/handlePINGMessage.js
@@ -1,3 +1,3 @@
 export default (message, connection) => {
-	connection.sendPong()
+	connection.sendPong(message.params.join(" "));
 }

--- a/src/structures/Connection.js
+++ b/src/structures/Connection.js
@@ -330,8 +330,12 @@ export default class extends EventEmitter {
 		this.send(motdMessages)
 	}
 
-	sendPong = () => {
-		this.send('PONG')
+	sendPong = (payload) => {
+		if (payload) {
+			this.send(`PONG ${payload}`)
+		} else {
+			this.send(`PONG`)
+		}
 	}
 
 	sendUnknownCommand = command => {

--- a/test/structures/Connection.test.js
+++ b/test/structures/Connection.test.js
@@ -260,6 +260,13 @@ describe('Connection', function() {
 				})
 			})
 
+			describe('PING with args', () => {
+				it('should send a PONG message', () => {
+					socket.emit('message', 'PING custom arg')
+					expect(connection.send.calledOnceWithExactly('PONG custom arg')).to.be.true
+				})
+			})
+
 			xdescribe('PONG', () => {
 				it('should clear the ping timeout', () => {})
 			})


### PR DESCRIPTION
When a PING is sent to TMI, you can send in an optional parameter, like
this:
`PING optional parameter`
When TMI responds (and most other IRC servers) with a PONG, they repeat the optional
parameter back to you, like this:
`PONG optional parameter`

I have added tests to ensure this new functionality works as expected
