### PR TITLE
fix CAP REQ reply not being read as trailing param

### DIFF
--- a/src/helpers/handleCAPMessage.js
+++ b/src/helpers/handleCAPMessage.js
@@ -19,7 +19,7 @@ export default (message, connection) => {
 		sendMOTD,
 		sendUnknownCommand,
 	} = connection
-	const [subcommand, ...args] = message.params
+	const [subcommand, arg] = message.params
 
 	switch (subcommand.toUpperCase()) {
 		case 'END':
@@ -33,8 +33,9 @@ export default (message, connection) => {
 			break
 
 		case 'REQ':
-			addCapabilities(args)
-			send(`:${HOST} CAP * ACK :${args?.filter(capability => CAPABILITIES.includes(capability)).join(' ')}`)
+			const capabilities = arg?.split(' ') ?? []
+			addCapabilities(capabilities)
+			send(`:${HOST} CAP * ACK :${capabilities.filter(capability => CAPABILITIES.includes(capability)).join(' ')}`)
 			connection.capabilitiesFinished = true
 			connection.emit('acknowledge')
 			break

--- a/test/structures/Connection.test.js
+++ b/test/structures/Connection.test.js
@@ -123,7 +123,7 @@ describe('Connection', function() {
 
 				describe('REQ subcommand', () => {
 					it('should acknowledge capabilities', () => {
-						socket.emit('message', `CAP REQ ${CAPABILITIES.join(' ')}`)
+						socket.emit('message', `CAP REQ :${CAPABILITIES.join(' ')}`)
 
 						const [[rawMessage]] = socket.send.args
 						const {
@@ -141,7 +141,7 @@ describe('Connection', function() {
 					})
 
 					it('should ignore unrecognized capabilities', () => {
-						socket.emit('message', `CAP REQ ${CAPABILITIES.join(' ')} foobar`)
+						socket.emit('message', `CAP REQ :${CAPABILITIES.join(' ')} foobar`)
 
 						const [[rawMessage]] = socket.send.args
 						const {


### PR DESCRIPTION
Fixes `CAP REQ` not being read as having a trailing param, which results in a non-conforming response that ACKs an empty list of capabilities.